### PR TITLE
Removing double question in TubeShapedBox

### DIFF
--- a/living-room/hallway/bedroom/TubeShapedBox.py
+++ b/living-room/hallway/bedroom/TubeShapedBox.py
@@ -43,10 +43,6 @@ def main():
     
     n.narrate()
 
-    n.path.change(q.ask())
-
-    n.narrate()
-
     cwd = Checkpoint.check_flag("cwd")
     location = Checkpoint.check_flag(q.choice)
     


### PR DESCRIPTION
`TubeShapedBox` asks questions twice instead of once; this isn't a loop issue, it's just _literally_ asking the question and narrating twice. Fixes #9 .